### PR TITLE
Setup function in the site integration script should be executed after the default setup function.

### DIFF
--- a/src/advantage/wrapper.ts
+++ b/src/advantage/wrapper.ts
@@ -166,10 +166,10 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
                 }
             }
             try {
+                await formatConfig.setup(this, this.messageHandler.ad?.iframe);
                 await Advantage.getInstance()
                     .formatIntegrations.get(format)
                     ?.setup(this, this.messageHandler.ad?.iframe);
-                await formatConfig.setup(this, this.messageHandler.ad?.iframe);
                 resolve();
             } catch (error) {
                 this.reset();


### PR DESCRIPTION
When creating an integration script for nyteknik.se, I discovered that some modifications I did in the integration script was over-written by default values. 

The reason was the execution order of setup functions defined in wrapper.ts.