### PR TITLE
feat(topscroll): option to set close animation duration

### DIFF
--- a/src/advantage/formats/topscroll.css
+++ b/src/advantage/formats/topscroll.css
@@ -1,4 +1,5 @@
 :host {
+    --adv-close-button-animation-duration: 0.5s;
     --adv-topscroll-height: 80svh;
     display: block;
     position: relative;
@@ -8,7 +9,7 @@
 }
 
 :host(.animate) {
-    transition: height 0.5s;
+    transition: height var(--adv-close-button-animation-duration);
 }
 
 #container {

--- a/src/advantage/formats/topscroll.ts
+++ b/src/advantage/formats/topscroll.ts
@@ -20,7 +20,8 @@ export const topscroll: AdvantageFormat = {
             closeButton: true,
             closeButtonText: "Close ad",
             downArrow: true,
-            height: 80
+            height: 80,
+            closeButtonAnimationDuration: 0.5
         };
         const config = { ...defaults, ...(options || {}) };
 
@@ -54,6 +55,10 @@ export const topscroll: AdvantageFormat = {
                 wrapper.uiLayer.style.setProperty(
                     "--before-content",
                     `'${config.closeButtonText}'`
+                );
+                wrapper.style.setProperty(
+                    "--adv-close-button-animation-duration",
+                    `${config.closeButtonAnimationDuration}s`
                 );
             }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,7 @@ export interface AdvantageFormat {
 export interface AdvantageFormatOptions {
     closeButton?: boolean;
     closeButtonText?: string;
+    closeButtonAnimationDuration?: number;
     downArrow?: boolean;
     height?: number;
 }


### PR DESCRIPTION
Instead of a boolean, we decided to introduce an option called closeButtonAnimationDuration. The duration has a default number of 0.5(s),

