### PR TITLE
fix(welcome page): hide site title on small screens

### DIFF
--- a/src/advantage/formats/welcomepage-ui.css
+++ b/src/advantage/formats/welcomepage-ui.css
@@ -83,6 +83,10 @@ span.arrow {
   transform: translateX(.25em);
 }
 
+.continue .to-label {
+  display: none;
+}
+
 .favico {
   width: auto;
   height: 1.5rem;
@@ -159,5 +163,11 @@ span.arrow {
 
   .countdown {
     transform: scale(.9);
+  }
+}
+
+@media (min-width: 600px) {
+  .continue .to-label {
+    display: inline-block;
   }
 }

--- a/src/advantage/formats/welcomepage.ts
+++ b/src/advantage/formats/welcomepage.ts
@@ -18,10 +18,10 @@ export const welcomePage: AdvantageFormat = {
         "Positioned on top of the site content with a close button to continue to the site",
     setup: (wrapper, ad, options) => {
         const defaults: AdvantageFormatOptions = {
-            autoCloseDuration: 12,
+            autoCloseDuration: 21,
             siteTitle: window.location.hostname,
             logo: `https://icons.duckduckgo.com/ip3/${window.location.hostname}.ico`,
-            continueToLabel: "Continue to",
+            continueToLabel: "To",
             scrollBackToTop: false,
             adLabel: "Advertisement"
         };
@@ -54,13 +54,15 @@ export const welcomePage: AdvantageFormat = {
                       }</span></span>
                     </div>
                     <div class="label">${config.adLabel}</div>
-                    <div class="continue">${
-                        config.logo
-                            ? `<img class="favico" src="${config.logo}" onerror="this.style.display='none'" />`
-                            : ``
-                    } ${config.continueToLabel} ${
-                    config.siteTitle
-                } <span class="arrow">➜</span></div>
+                    <div class="continue">
+                        ${
+                            config.logo
+                                ? `<img class="favico" src="${config.logo}" onerror="this.style.display='none'" />`
+                                : ""
+                        }<span class="to-label">${config.continueToLabel} ${
+                    config.siteTitle ? config.siteTitle : ""
+                }</span><span class="arrow">➜</span>
+                    </div>
                   </div>
                 </div>`
             );


### PR DESCRIPTION
### Description
_Describe what this change achieves._

This PR handle welcome page header more elegant on smaller screen.

<img width="446" alt="image" src="https://github.com/user-attachments/assets/72c9ee0e-d571-4ca7-8f34-c83a6369ebf7">


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

closes #33 

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 license.
