### PR TITLE
Fallback when "CSSStyleSheet" not supported

### DIFF
--- a/src/advantage/ui-layer.ts
+++ b/src/advantage/ui-layer.ts
@@ -1,3 +1,4 @@
+import { supportsAdoptingStyleSheets } from "../utils";
 /**
  * Represents the UI layer for an Advantage high-impact format.
  * This class extends the HTMLElement class and provides methods for manipulating the UI content and styles.
@@ -15,7 +16,7 @@ export class AdvantageUILayer extends HTMLElement {
      */
     constructor() {
         super();
-        if (document.adoptedStyleSheets != undefined) {
+        if (supportsAdoptingStyleSheets) {
             this.#styleSheet = new CSSStyleSheet();
         } else {
             this.#styleSheet = document.createElement(
@@ -23,7 +24,7 @@ export class AdvantageUILayer extends HTMLElement {
             ) as HTMLStyleElement;
         }
         this.#root = this.attachShadow({ mode: "open" });
-        if (document.adoptedStyleSheets != undefined) {
+        if (supportsAdoptingStyleSheets) {
             this.#root.adoptedStyleSheets = [this.#styleSheet as CSSStyleSheet];
         } else {
             this.#root.appendChild(this.#styleSheet as HTMLStyleElement);
@@ -54,7 +55,7 @@ export class AdvantageUILayer extends HTMLElement {
      * @param CSS - The CSS styles to be inserted.
      */
     insertCSS(CSS: string) {
-        if (document.adoptedStyleSheets != undefined) {
+        if (supportsAdoptingStyleSheets) {
             (this.#styleSheet as CSSStyleSheet).replaceSync(CSS);
         } else {
             (this.#styleSheet as HTMLStyleElement).textContent = CSS;

--- a/src/advantage/ui-layer.ts
+++ b/src/advantage/ui-layer.ts
@@ -15,7 +15,7 @@ export class AdvantageUILayer extends HTMLElement {
      */
     constructor() {
         super();
-        if ("CSSStyleSheet" in window) {
+        if (document.adoptedStyleSheets != undefined) {
             this.#styleSheet = new CSSStyleSheet();
         } else {
             this.#styleSheet = document.createElement(
@@ -23,7 +23,7 @@ export class AdvantageUILayer extends HTMLElement {
             ) as HTMLStyleElement;
         }
         this.#root = this.attachShadow({ mode: "open" });
-        if ("CSSStyleSheet" in window) {
+        if (document.adoptedStyleSheets != undefined) {
             this.#root.adoptedStyleSheets = [this.#styleSheet as CSSStyleSheet];
         } else {
             this.#root.appendChild(this.#styleSheet as HTMLStyleElement);
@@ -54,7 +54,7 @@ export class AdvantageUILayer extends HTMLElement {
      * @param CSS - The CSS styles to be inserted.
      */
     insertCSS(CSS: string) {
-        if ("CSSStyleSheet" in window) {
+        if (document.adoptedStyleSheets != undefined) {
             (this.#styleSheet as CSSStyleSheet).replaceSync(CSS);
         } else {
             (this.#styleSheet as HTMLStyleElement).textContent = CSS;

--- a/src/advantage/ui-layer.ts
+++ b/src/advantage/ui-layer.ts
@@ -5,7 +5,7 @@
  */
 export class AdvantageUILayer extends HTMLElement {
     #root: ShadowRoot;
-    #styleSheet: CSSStyleSheet;
+    #styleSheet: CSSStyleSheet | HTMLStyleElement;
     #container: HTMLDivElement;
     #content: HTMLDivElement;
     slotName = "advantage-ui-content";
@@ -15,9 +15,19 @@ export class AdvantageUILayer extends HTMLElement {
      */
     constructor() {
         super();
-        this.#styleSheet = new CSSStyleSheet();
+        if ("CSSStyleSheet" in window) {
+            this.#styleSheet = new CSSStyleSheet();
+        } else {
+            this.#styleSheet = document.createElement(
+                "style"
+            ) as HTMLStyleElement;
+        }
         this.#root = this.attachShadow({ mode: "open" });
-        this.#root.adoptedStyleSheets = [this.#styleSheet];
+        if ("CSSStyleSheet" in window) {
+            this.#root.adoptedStyleSheets = [this.#styleSheet as CSSStyleSheet];
+        } else {
+            this.#root.appendChild(this.#styleSheet as HTMLStyleElement);
+        }
         this.#container = document.createElement("div");
         this.#container.id = "container";
         this.#content = document.createElement("div");
@@ -44,6 +54,10 @@ export class AdvantageUILayer extends HTMLElement {
      * @param CSS - The CSS styles to be inserted.
      */
     insertCSS(CSS: string) {
-        this.#styleSheet.replaceSync(CSS);
+        if ("CSSStyleSheet" in window) {
+            (this.#styleSheet as CSSStyleSheet).replaceSync(CSS);
+        } else {
+            (this.#styleSheet as HTMLStyleElement).textContent = CSS;
+        }
     }
 }

--- a/src/advantage/wrapper.ts
+++ b/src/advantage/wrapper.ts
@@ -1,7 +1,7 @@
 import { Advantage } from "./advantage";
 import { IAdvantageUILayer, IAdvantageWrapper } from "../types";
 
-import { logger, traverseNodes } from "../utils";
+import { logger, traverseNodes, supportsAdoptingStyleSheets } from "../utils";
 
 import { AdvantageAdSlotResponder } from "./messaging/publisher-side";
 
@@ -29,7 +29,7 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
      */
     constructor() {
         super();
-        if (document.adoptedStyleSheets != undefined) {
+        if (supportsAdoptingStyleSheets) {
             this.#styleSheet = new CSSStyleSheet();
         } else {
             this.#styleSheet = document.createElement(
@@ -39,7 +39,7 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
 
         this.#root = this.attachShadow({ mode: "open" });
 
-        if (document.adoptedStyleSheets != undefined) {
+        if (supportsAdoptingStyleSheets) {
             this.#root.adoptedStyleSheets = [this.#styleSheet as CSSStyleSheet];
         } else {
             this.#root.appendChild(this.#styleSheet as HTMLStyleElement);
@@ -318,7 +318,7 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
      * @param CSS - The CSS to insert.
      */
     insertCSS(CSS: string) {
-        if (document.adoptedStyleSheets != undefined) {
+        if (supportsAdoptingStyleSheets) {
             (this.#styleSheet as CSSStyleSheet).replaceSync(CSS);
         } else {
             (this.#styleSheet as HTMLStyleElement).textContent = CSS;
@@ -329,7 +329,7 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
      * Resets the CSS in the shadow root of the wrapper.
      */
     resetCSS() {
-        if (document.adoptedStyleSheets != undefined) {
+        if (supportsAdoptingStyleSheets) {
             (this.#styleSheet as CSSStyleSheet).replaceSync("");
         } else {
             (this.#styleSheet as HTMLStyleElement).textContent = "";

--- a/src/advantage/wrapper.ts
+++ b/src/advantage/wrapper.ts
@@ -29,7 +29,7 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
      */
     constructor() {
         super();
-        if ("CSSStyleSheet" in window) {
+        if (document.adoptedStyleSheets != undefined) {
             this.#styleSheet = new CSSStyleSheet();
         } else {
             this.#styleSheet = document.createElement(
@@ -39,7 +39,7 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
 
         this.#root = this.attachShadow({ mode: "open" });
 
-        if ("CSSStyleSheet" in window) {
+        if (document.adoptedStyleSheets != undefined) {
             this.#root.adoptedStyleSheets = [this.#styleSheet as CSSStyleSheet];
         } else {
             this.#root.appendChild(this.#styleSheet as HTMLStyleElement);
@@ -318,7 +318,7 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
      * @param CSS - The CSS to insert.
      */
     insertCSS(CSS: string) {
-        if ("CSSStyleSheet" in window) {
+        if (document.adoptedStyleSheets != undefined) {
             (this.#styleSheet as CSSStyleSheet).replaceSync(CSS);
         } else {
             (this.#styleSheet as HTMLStyleElement).textContent = CSS;
@@ -329,7 +329,7 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
      * Resets the CSS in the shadow root of the wrapper.
      */
     resetCSS() {
-        if ("CSSStyleSheet" in window) {
+        if (document.adoptedStyleSheets != undefined) {
             (this.#styleSheet as CSSStyleSheet).replaceSync("");
         } else {
             (this.#styleSheet as HTMLStyleElement).textContent = "";

--- a/src/advantage/wrapper.ts
+++ b/src/advantage/wrapper.ts
@@ -12,7 +12,7 @@ import { AdvantageAdSlotResponder } from "./messaging/publisher-side";
  */
 export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
     // Private fields
-    #styleSheet: CSSStyleSheet;
+    #styleSheet: CSSStyleSheet | HTMLStyleElement;
     #root: ShadowRoot;
     #slotAdvantageContent: HTMLSlotElement;
     #slotChangeRegistered = false;
@@ -29,9 +29,21 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
      */
     constructor() {
         super();
-        this.#styleSheet = new CSSStyleSheet();
+        if ("CSSStyleSheet" in window) {
+            this.#styleSheet = new CSSStyleSheet();
+        } else {
+            this.#styleSheet = document.createElement(
+                "style"
+            ) as HTMLStyleElement;
+        }
+
         this.#root = this.attachShadow({ mode: "open" });
-        this.#root.adoptedStyleSheets = [this.#styleSheet];
+
+        if ("CSSStyleSheet" in window) {
+            this.#root.adoptedStyleSheets = [this.#styleSheet as CSSStyleSheet];
+        } else {
+            this.#root.appendChild(this.#styleSheet as HTMLStyleElement);
+        }
 
         // Create the container div
         this.container = document.createElement("div");
@@ -306,14 +318,22 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
      * @param CSS - The CSS to insert.
      */
     insertCSS(CSS: string) {
-        this.#styleSheet.replaceSync(CSS);
+        if ("CSSStyleSheet" in window) {
+            (this.#styleSheet as CSSStyleSheet).replaceSync(CSS);
+        } else {
+            (this.#styleSheet as HTMLStyleElement).textContent = CSS;
+        }
     }
 
     /**
      * Resets the CSS in the shadow root of the wrapper.
      */
     resetCSS() {
-        this.#styleSheet.replaceSync("");
+        if ("CSSStyleSheet" in window) {
+            (this.#styleSheet as CSSStyleSheet).replaceSync("");
+        } else {
+            (this.#styleSheet as HTMLStyleElement).textContent = "";
+        }
     }
 
     /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { default as logger } from "./logging";
-export { collectIframes, traverseNodes } from "./misc";
+export { collectIframes, traverseNodes, supportsAdoptingStyleSheets } from "./misc";
 export {
     ADVANTAGE,
     sendMessageAndOpenChannel,

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -42,3 +42,10 @@ export const traverseNodes = (
         }
     }
 };
+
+/**
+ * Checks if the browser supports adopting style sheets.
+ */
+export const supportsAdoptingStyleSheets =
+    "adoptedStyleSheets" in Document.prototype &&
+    "replace" in CSSStyleSheet.prototype;


### PR DESCRIPTION
### Description
CSSStyleSheet not supported in older browsers.

### Issues Resolved
Create a fallback solution for when CSSStyleSheet is not supported.

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 license.
