### PR TITLE
Add JSON build script and postbuild hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
         "docs:preview": "vitepress preview",
         "test": "jest",
         "test-server": "node test-server.js",
-        "release": "dotenv release-it --"
+        "release": "dotenv release-it --",
+        "generate-formats-json": "node scripts/generate-formats-json.cjs",
+        "postbuild": "npm run generate-formats-json"
     },
     "devDependencies": {
         "@release-it/conventional-changelog": "^8.0.1",

--- a/scripts/generate-formats-json.cjs
+++ b/scripts/generate-formats-json.cjs
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const path = require("path");
+
+// --- minimal browser‑like globals so the ESM bundle doesn't crash in Node ---
+if (typeof globalThis.window === "undefined") {
+    globalThis.window = {};
+}
+if (typeof globalThis.document === "undefined") {
+    globalThis.document = {};
+}
+// some libraries look for window.location or window.navigator; stub them
+globalThis.window.location = globalThis.window.location || {};
+globalThis.window.navigator = globalThis.window.navigator || {};
+// if the code asks for addEventListener/removeEventListener just give no‑ops
+globalThis.window.addEventListener = () => {};
+globalThis.window.removeEventListener = () => {};
+
+(async () => {
+    const { defaultFormats } = await import(
+        "../dist/advantage/formats/index.js"
+    );
+
+    const formats = defaultFormats;
+    const outputPath = path.resolve(__dirname, "../dist/formats.json");
+
+    fs.writeFileSync(outputPath, JSON.stringify(formats, null, 2));
+    console.log(`Formats JSON written to ${outputPath}`);
+})().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
### Description
This PR **automatically publishes an always-up-to-date `formats.json`** with every build.

* **`scripts/generate-formats-json.cjs`**  
  * Dynamically imports the freshly-compiled `dist/advantage/formats` bundle (so there are no TypeScript or CSS-loader headaches).  
  * Extracts `name` and `description` for every format and writes them to `dist/formats.json`.  
  * Includes a tiny browser-stub (`window` / `document`) so the ESM bundle can be evaluated in Node without side effects.

* **`package.json`**  
  * Adds the script:  
    ```json
    "generate-formats-json": "node scripts/generate-formats-json.cjs",
    "postbuild": "npm run generate-formats-json"
    ```  
    The hook runs **after every `npm run build`** and therefore after each publish.

With the file living in `dist/`, it is served automatically by npm CDNs, e.g.:
https://cdn.jsdelivr.net/npm/@get-advantage/advantage@latest/dist/formats.json

Third-party services can now fetch the current list of formats at a stable URL and stay in sync without manual updates.

No production/runtime code is touched; only the build pipeline is extended.

### Issues Resolved
Closes #45 – *“Publicly accessible JSON endpoint for the list of implemented formats”*

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 license.
