### PR TITLE
feat: allowed-formats

### DIFF
--- a/playground/local-dev/index.html
+++ b/playground/local-dev/index.html
@@ -1,657 +1,681 @@
 <!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Advantage</title>
+        <script src="https://cdn.tailwindcss.com"></script>
+        <style>
+            html {
+                overflow-x: hidden;
+            }
+        </style>
+        <script>
+            window.advantageCmdQueue = window.advantageCmdQueue || [];
+        </script>
+        <script type="module" src="./index.ts"></script>
+    </head>
 
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Advantage</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        html {
-            overflow-x: hidden;
-        }
-    </style>
-    <script>
-        window.advantageCmdQueue = window.advantageCmdQueue || [];
-    </script>
-    <script type="module" src="./index.ts"></script>
-</head>
-
-<body>
-    <advantage-wrapper>
-        <div slot="advantage-ad-slot">
-            <iframe src="./topscroll/topscroll.html" title="advantage-ad" style="border: 0; width: 0; height: 0"
-                scrolling="no"></iframe>
+    <body>
+        <advantage-wrapper id="allowed-formats-wrapper">
+            <div slot="advantage-ad-slot">
+                <iframe
+                    src="./topscroll/topscroll.html"
+                    title="advantage-ad"
+                    style="border: 0; width: 0; height: 0"
+                    scrolling="no"
+                ></iframe>
+            </div>
+        </advantage-wrapper>
+        <advantage-wrapper allowed-formats="TOPSCROLL">
+            <div slot="advantage-ad-slot">
+                <iframe
+                    src="./topscroll/topscroll.html"
+                    title="advantage-ad"
+                    style="border: 0; width: 0; height: 0"
+                    scrolling="no"
+                ></iframe>
+            </div>
+        </advantage-wrapper>
+        <div class="container mx-auto px-4 py-4">
+            <section
+                class="grid grid-cols-1 lg:gap-6 lg:grid-cols-2 lg:grid-rows-3"
+            >
+                <article class="py-4">
+                    <h1 class="sans-serif text-2xl font-bold mb-4">
+                        Advantage Unveiled: Unlocking Potential
+                    </h1>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        The Advantage Edge: Strategies for Success
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        Harnessing the Power of Advantage
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        Advantage Point: Seeing Opportunities Where Others See
+                        Challenges
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        Leveraging Your Advantage: A Guide to Growth
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        Advantage Horizon: Peering Into the Future
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+            </section>
         </div>
-    </advantage-wrapper>
-    <div class="container mx-auto px-4 py-4">
-        <section class="grid grid-cols-1 lg:gap-6 lg:grid-cols-2 lg:grid-rows-3">
-            <article class="py-4">
-                <h1 class="sans-serif text-2xl font-bold mb-4">
-                    Advantage Unveiled: Unlocking Potential
-                </h1>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    The Advantage Edge: Strategies for Success
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    Harnessing the Power of Advantage
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    Advantage Point: Seeing Opportunities Where Others See
-                    Challenges
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    Leveraging Your Advantage: A Guide to Growth
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    Advantage Horizon: Peering Into the Future
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-        </section>
-    </div>
-    <advantage-wrapper exclude-formats="TOPSCROLL,MIDSCROLL">
-        <div slot="advantage-ad-slot">
-            <iframe src="./topscroll/topscroll.html" title="advantage-ad" style="border: 0; width: 0; height: 0"
-                scrolling="no"></iframe>
-        </div>
-    </advantage-wrapper>
+        <advantage-wrapper allowed-formats="MIDSCROLL">
+            <div slot="advantage-ad-slot">
+                <iframe
+                    src="./topscroll/topscroll.html"
+                    title="advantage-ad"
+                    style="border: 0; width: 0; height: 0"
+                    scrolling="no"
+                ></iframe>
+            </div>
+        </advantage-wrapper>
 
-    <div id="ad-slot-to-be-wrapped" style="width: 100%">
-        <iframe id="midscroll" src="./midscroll/midscroll.html" title="advantage-ad" style="
+        <div id="ad-slot-to-be-wrapped" style="width: 100%">
+            <iframe
+                id="midscroll"
+                src="./midscroll/midscroll.html"
+                title="advantage-ad"
+                style="
                     display: block;
                     border: 0;
                     width: 320px;
                     height: 320px;
                     margin-left: auto;
                     margin-right: auto;
-                " scrolling="no"></iframe>
-    </div>
-    <div class="container mx-auto px-4 py-4">
-        <section class="grid grid-cols-1 lg:gap-6 lg:grid-cols-2 lg:grid-rows-3">
-            <article class="py-4">
-                <h1 class="sans-serif text-2xl font-bold mb-4">
-                    Advantage Unveiled: Unlocking Potential
-                </h1>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    The Advantage Formula: Crafting Winning Strategies
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    Harnessing the Power of Advantage
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    Advantage Point: Seeing Opportunities Where Others See
-                    Challenges
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    Leveraging Your Advantage: A Guide to Growth
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-            <article class="py-4">
-                <h2 class="sans-serif text-xl font-bold mb-4">
-                    Advantage Horizon: Peering Into the Future
-                </h2>
-                <p>
-                    Future Text Placeholder: Here lies a realm of
-                    possibility, a dedicated space for words that have not
-                    yet found their way. This is a nondescript sentinel,
-                    guarding the empty space with a promise of content to
-                    come. It’s a placeholder, calm and collected, offering
-                    no opinions or statements, just the quiet assurance that
-                    this void will soon be filled. It's a testament to the
-                    pending creativity and knowledge that will eventually
-                    inhabit this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-                <p>
-                    Reserved for Future Musings: This space is currently
-                    under the gentle guard of placeholder text, serving as a
-                    temporary custodian of the future's narratives. It
-                    stands quietly at the ready, offering a blank slate for
-                    the stories and insights yet to unfold. Here, words will
-                    eventually bloom, filling the void with vibrant thoughts
-                    and ideas. Until then, this placeholder remains, a
-                    silent herald of the content that will soon cascade into
-                    this space.
-                </p>
-                <p>
-                    Content Placeholder in Progress: Imagine this as a
-                    placeholder, a serene placeholder, devoid of meaning yet
-                    full of potential. It exists simply to hold a spot, a
-                    quiet placeholder until the real words take their
-                    rightful place. It's a space where future thoughts will
-                    dwell, a prelude to the insightful discourse that is yet
-                    to emerge. For now, it patiently waits, a beacon for the
-                    forthcoming text that will soon illuminate this segment
-                    with purpose.
-                </p>
-            </article>
-        </section>
-    </div>
-    <script>
-        // This is a helper function to wrap an ad slot element with an Advantage-wrapper
-        // The advantageCmdQueue will be executed by the Advantage-wrapper script when it is loaded
-        window.advantageCmdQueue.push(
-            (advantageWrapAdSlotElement) => {
+                "
+                scrolling="no"
+            ></iframe>
+        </div>
+        <div class="container mx-auto px-4 py-4">
+            <section
+                class="grid grid-cols-1 lg:gap-6 lg:grid-cols-2 lg:grid-rows-3"
+            >
+                <article class="py-4">
+                    <h1 class="sans-serif text-2xl font-bold mb-4">
+                        Advantage Unveiled: Unlocking Potential
+                    </h1>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        The Advantage Formula: Crafting Winning Strategies
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        Harnessing the Power of Advantage
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        Advantage Point: Seeing Opportunities Where Others See
+                        Challenges
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        Leveraging Your Advantage: A Guide to Growth
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+                <article class="py-4">
+                    <h2 class="sans-serif text-xl font-bold mb-4">
+                        Advantage Horizon: Peering Into the Future
+                    </h2>
+                    <p>
+                        Future Text Placeholder: Here lies a realm of
+                        possibility, a dedicated space for words that have not
+                        yet found their way. This is a nondescript sentinel,
+                        guarding the empty space with a promise of content to
+                        come. It’s a placeholder, calm and collected, offering
+                        no opinions or statements, just the quiet assurance that
+                        this void will soon be filled. It's a testament to the
+                        pending creativity and knowledge that will eventually
+                        inhabit this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                    <p>
+                        Reserved for Future Musings: This space is currently
+                        under the gentle guard of placeholder text, serving as a
+                        temporary custodian of the future's narratives. It
+                        stands quietly at the ready, offering a blank slate for
+                        the stories and insights yet to unfold. Here, words will
+                        eventually bloom, filling the void with vibrant thoughts
+                        and ideas. Until then, this placeholder remains, a
+                        silent herald of the content that will soon cascade into
+                        this space.
+                    </p>
+                    <p>
+                        Content Placeholder in Progress: Imagine this as a
+                        placeholder, a serene placeholder, devoid of meaning yet
+                        full of potential. It exists simply to hold a spot, a
+                        quiet placeholder until the real words take their
+                        rightful place. It's a space where future thoughts will
+                        dwell, a prelude to the insightful discourse that is yet
+                        to emerge. For now, it patiently waits, a beacon for the
+                        forthcoming text that will soon illuminate this segment
+                        with purpose.
+                    </p>
+                </article>
+            </section>
+        </div>
+        <script>
+            // This is a helper function to wrap an ad slot element with an Advantage-wrapper
+            // The advantageCmdQueue will be executed by the Advantage-wrapper script when it is loaded
+            window.advantageCmdQueue.push((advantageWrapAdSlotElement) => {
                 // advantageWrapAdSlotElement is a function that wraps an ad slot element with an Advantage-wrapper. It takes either a selector string or an HTMLElement as an argument.
                 // You can also pass an optional second argument to specify the formats to exclude for the wrapped ad slot.
                 advantageWrapAdSlotElement("#ad-slot-to-be-wrapped", [
                     "TOPSCROLL"
                 ]);
-            }
-        );
-    </script>
-</body>
-
+            });
+        </script>
+    </body>
 </html>

--- a/playground/local-dev/index.ts
+++ b/playground/local-dev/index.ts
@@ -1,4 +1,4 @@
-import { Advantage } from "@src/advantage";
+import { Advantage, IAdvantageWrapper } from "@src/advantage";
 import localConfig from "./config";
 
 /* 
@@ -21,3 +21,9 @@ advantage.configure({
     /* Or use a local configuration */
     ...localConfig
 });
+
+const allowedFormatsWrapper = document.querySelector(
+    "#allowed-formats-wrapper"
+) as IAdvantageWrapper;
+allowedFormatsWrapper.setAllowedFormats(["WELCOMEPAGE"]);
+console.log("Allowed formats: ", allowedFormatsWrapper.allowedFormats);

--- a/src/advantage/wrapper.ts
+++ b/src/advantage/wrapper.ts
@@ -16,6 +16,8 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
     #root: ShadowRoot;
     #slotAdvantageContent: HTMLSlotElement;
     #slotChangeRegistered = false;
+    // Whitelist set via attribute or API; when present it overrides exclude‑formats
+    allowedFormats: string[] | null = null;
     // Public fields
     container: HTMLDivElement;
     content: HTMLDivElement;
@@ -162,24 +164,64 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
     };
 
     /**
+     * Restrict this wrapper to the given list of formats.
+     * Calling this method overrides any list previously set via attribute or API.
+     * @param formats Array of format names that are allowed for this wrapper.
+     */
+    setAllowedFormats(formats: string[]) {
+        this.allowedFormats = formats.map((f) => f.trim().toUpperCase());
+    }
+
+    /**
+     * Clears the programmatic whitelist so the wrapper falls back to attribute or default behaviour.
+     */
+    clearAllowedFormats() {
+        this.allowedFormats = null;
+    }
+
+    /**
      * Morphs the wrapper into a specific ad format.
+     * If `allowed-formats` is set (via attribute or API) it takes precedence over `exclude-formats`.
+     * Comparisons are case-insensitive.
      * @param format - The format to morph into.
      * @returns A promise that resolves when the morphing is complete.
      */
     morphIntoFormat = async (format: string) => {
         logger.debug("MORPH INTO FORMAT");
         return new Promise<void>(async (resolve, reject) => {
-            const forbiddenFormats = this.getAttribute("exclude-formats")
+            const formatId = format.toUpperCase();
+            // 1. Check for an explicit allow‑list (attribute or programmatic).
+            const attrAllowed = this.getAttribute("allowed-formats")
                 ?.split(",")
-                .map((format) => format.trim());
-            if (forbiddenFormats && forbiddenFormats.includes(format)) {
+                .map((f) => f.trim().toUpperCase())
+                .filter(Boolean);
+            const allowedList = this.allowedFormats ?? attrAllowed;
+            if (allowedList && !allowedList.includes(formatId)) {
                 logger.info(
-                    `This wrapper does not support the format(s): \"${forbiddenFormats.join(
+                    `The format "${formatId}" is not in the allowed-formats list (${allowedList.join(
                         ", "
-                    )}\".`
+                    )}).`
                 );
                 reject(
-                    `The format ${format} is forbidden for this wrapper. 🛑`
+                    `The format ${formatId} is not allowed for this wrapper. 🛑`
+                );
+                return;
+            }
+
+            // 2. If no allow‑list, fall back to exclude‑list logic.
+            const forbiddenFormats = !allowedList
+                ? this.getAttribute("exclude-formats")
+                      ?.split(",")
+                      .map((f) => f.trim().toUpperCase())
+                : undefined;
+            if (forbiddenFormats && forbiddenFormats.includes(formatId)) {
+                logger.info(
+                    `This wrapper does not support the format(s): "${forbiddenFormats.join(
+                        ", "
+                    )}".`
+                );
+                reject(
+                    `The format ${formatId} is forbidden for this wrapper. 🛑`
                 );
                 return;
             }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export interface IAdvantageWrapper extends HTMLElement {
     currentFormat: AdvantageFormatName | string | null;
     uiLayer: IAdvantageUILayer;
     contentNodes: Node[];
+    allowedFormats: string[] | null;
     morphIntoFormat: (format: AdvantageFormatName | string) => Promise<void>;
     applyStylesToAllChildElements: (styles: string) => void;
     insertCSS: (CSS: string) => void;
@@ -46,6 +47,8 @@ export interface IAdvantageWrapper extends HTMLElement {
     changeContent: (content: string | HTMLElement) => void;
     simulateFormat: (format: AdvantageFormatName | string) => Promise<void>;
     animateClose: () => void;
+    setAllowedFormats: (formats: string[]) => void;
+    clearAllowedFormats: () => void;
 }
 
 export interface IAdvantageUILayer extends HTMLElement {

--- a/www/docs/concepts/formats.md
+++ b/www/docs/concepts/formats.md
@@ -16,6 +16,17 @@ Formats focus on:
 
 Formats in Advantage are essentially a definition of how an ad looks and behaves; Such as animation on scroll. The format offer a standardized interface that allows it to be initialized, displayed, and otherwise manipulated by the integration code.
 
+These are the current built-in format identifiers:
+
+```ts
+export enum AdvantageFormatName {
+    TopScroll = "TOPSCROLL",
+    DoubleMidscroll = "DOUBLE_MIDSCROLL",
+    Midscroll = "MIDSCROLL",
+    WelcomePage = "WELCOME_PAGE"
+}
+```
+
 ## Welcome Page
 
 An impactful format that welcomes users with swift and wide reach. Positioned on top of the site content with a close button to continue to the site offers ample creative freedom, allowing for work with high-resolution materials to ensure a high-quality experience and excellent outcomes.

--- a/www/docs/tutorial/publisher.md
+++ b/www/docs/tutorial/publisher.md
@@ -59,6 +59,31 @@ It is now time to wrap your ad slots in the Advantage Wrapper.
 </advantage-wrapper>
 ```
 
+You can control which ad formats are allowed for an `<advantage-wrapper>` by specifying them in the allowed-formats attribute. Provide a comma-separated list of format names; only these listed formats will be permitted for this specific wrapper instance.
+
+```html
+<advantage-wrapper allowed-formats="TOPSCROLL,WELCOMEPAGE">
+    <div slot="advantage-ad-slot">
+        <!-- YOUR AD SLOT HERE -->
+    </div>
+</advantage-wrapper>
+```
+
+You can also dynamically set or update the allowed ad formats for an `<advantage-wrapper>` instance using its setAllowedFormats() JavaScript method. This method is useful for changing format permissions after the page has loaded or in response to user interactions.
+
+Method: `element.setAllowedFormats(formatsArray)`
+
+-   `formatsArray`: An array of strings, where each string is a valid format identifier (e.g., `["MIDSCROLL", "WELCOME_PAGE"]`).
+-   Ensure the format identifiers used are valid. See a list of built-in formats [here](/docs/concepts/formats)
+
+```ts
+import { Advantage, IAdvantageWrapper } from "@get-advantage/advantage";
+const wrapper = document.querySelector(
+    "advantage-wrapper"
+) as IAdvantageWrapper;
+wrapper.setAllowedFormats(["MIDSCROLL", "WELCOME_PAGE"]);
+```
+
 You can also choose to use a helper method that does the wrapping for you:
 
 ```ts


### PR DESCRIPTION
### Description
This PR introduces support for an `allowed-formats` attribute, which acts as a whitelist specifying the formats an `AdvantageWrapper` instance is permitted to morph into. This functionality complements and takes precedence over the existing exclude-formats attribute when present.

A new property, `allowedFormats`, has been added to the `AdvantageWrapper` class. It can be set via the HTML attribute or programmatically using the following methods introduced in `IAdvantageWrapper`:

```ts
setAllowedFormats: (formats: string[]) => void;
clearAllowedFormats: () => void;
```

**Key behavior changes:**

- If allowed-formats is set (via attribute or API), it overrides exclude-formats.
- If not set, the legacy exclude-formats behavior remains unchanged.
- Format names are normalized to uppercase and trimmed for consistency.

**Documentation**:
Relevant sections of the documentation have been updated to include details on the new attribute and methods.


### Issues Resolved
Closses **Feature Request: allowed-formats attribute (and programmatic API)** #47

**Notes**
The core logic for this feature resides in the `morphIntoFormat` method of the `AdvantageWrapper` class. It evaluates the presence of `allowed-formats` (attribute or API) and gracefully falls back to `exclude-formats` if not defined.

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 license.
