### PR TITLE
fix: reset topscroll styles on close

### DIFF
--- a/src/advantage/formats/topscroll.ts
+++ b/src/advantage/formats/topscroll.ts
@@ -134,8 +134,11 @@ export const topscroll: AdvantageFormat = {
     },
     close: (wrapper) => {
         wrapper.animateClose(() => {
+            wrapper.resetCSS();
             wrapper.style.removeProperty("--adv-topscroll-height");
-            wrapper.style.removeProperty("--adv-close-button-animation-duration");
+            wrapper.style.removeProperty(
+                "--adv-close-button-animation-duration"
+            );
             wrapper.uiLayer.style.removeProperty("--before-content");
         });
     }

--- a/src/advantage/wrapper.ts
+++ b/src/advantage/wrapper.ts
@@ -461,13 +461,19 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
         logger.debug("Wrapper reset complete. Active iframe cleared.");
     }
 
-    animateClose() {
+    animateClose(callback?: () => void) {
         this.classList.add("animate");
         this.addEventListener(
             "transitionend",
             () => {
+                // If a new format has started (currentFormat is set), abort cleanup
+                if (this.currentFormat) {
+                    return;
+                }
                 this.style.display = "none";
-                this.resetCSS();
+                if (callback) {
+                    callback();
+                }
             },
             { once: true }
         );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,7 +55,7 @@ export interface IAdvantageWrapper extends HTMLElement {
     close: () => void;
     changeContent: (content: string | HTMLElement) => void;
     simulateFormat: (format: AdvantageFormatName | string) => Promise<void>;
-    animateClose: () => void;
+    animateClose: (callback?: () => void) => void;
     setAllowedFormats: (formats: string[]) => void;
     clearAllowedFormats: () => void;
 }


### PR DESCRIPTION
# Fix: TopScroll Style Cleanup & Wrapper Close Animation

## Summary
This PR fixes an issue where TopScroll format styles (CSS variables) persisted after the ad was closed or reset. It also improves the `AdvantageWrapper`'s `animateClose` method to ensure that CSS cleanup happens only *after* the closing animation has completed, preventing visual glitches during the transition.

## Changes

### `src/advantage/formats/topscroll.ts`
- Updated `reset` and `close` methods to explicitly remove the following CSS properties:
  - `--adv-topscroll-height`
  - `--adv-close-button-animation-duration`
  - `--before-content` (from the UI layer)
- This ensures that all styles applied during `setup` are properly undone.

### `src/advantage/wrapper.ts`
- Modified `animateClose` to wait for the `transitionend` event before cleaning up styles.
- Added `this.resetCSS()` inside the event listener to clear the shadow DOM styles once the element is hidden.
- Added `{ once: true }` to the event listener to ensure it only triggers once per close action.

## Testing
- [ ] **TopScroll Close**: Verify that clicking the close button on a TopScroll ad plays the animation smoothly and then removes the ad and its styles.
- [ ] **TopScroll Reset**: Verify that resetting the format# Fix: TopScroll Style Cleanup & Wrapper Close Animation

## Summary
This PR fixes an issue where TopScroll format styles (CSS variables) persisted after the ad was closed or reset. It also improves the `AdvantageWrapper`'s `animateClose` method to ensure that CSS cleanup happens only *after* the closing animation has completed, preventing visual glitches during the transition.

## Changes

### `src/advantage/formats/topscroll.ts`
- Updated `reset` and `close` methods to explicitly remove the following CSS properties:
  - `--adv-topscroll-height`
  - `--adv-close-button-animation-duration`
  - `--before-content` (from the UI layer)
- This ensures that all styles applied during `setup` are properly undone.

### `src/advantage/wrapper.ts`
- Modified `animateClose` to wait for the `transitionend` event before cleaning up styles.
- Added `this.resetCSS()` inside the event listener to clear the shadow DOM styles once the element is hidden.
- Added `{ once: true }` to the event listener to ensure it only triggers once per close action.

## Testing
- [ ] **TopScroll Close**: Verify that clicking the close button on a TopScroll ad plays the animation smoothly and then removes the ad and its styles.
- [ ] **TopScroll Reset**: Verify that resetting the format