### PR TITLE
fix: fullscreen width + docs for single creative format

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -151,6 +151,10 @@ export default defineConfig({
                             text: `Double Midscroll`,
                             link: "/docs/formats/double_midscroll.md"
                         },
+                        {
+                            text: `Double Midscroll Single Creative`,
+                            link: "/docs/formats/double_midscroll_single_creative.md"
+                        },
                     ]
                 },
                 {

--- a/src/advantage/formats/double-midscroll-single.css
+++ b/src/advantage/formats/double-midscroll-single.css
@@ -2,6 +2,7 @@
     display: block;
     position: relative;
     width: 100vw;
+    margin-left: calc((100% - 100vw) / 2);
     height: 200vh;
     overflow: visible;
 }

--- a/src/advantage/formats/double-midscroll-single.css
+++ b/src/advantage/formats/double-midscroll-single.css
@@ -2,7 +2,6 @@
     display: block;
     position: relative;
     width: 100vw;
-    margin-left: calc((100% - 100vw) / 2);
     height: 200vh;
     overflow: visible;
 }

--- a/src/advantage/formats/double-midscroll-single.ts
+++ b/src/advantage/formats/double-midscroll-single.ts
@@ -30,7 +30,12 @@ export const doubleMidscrollSingle: AdvantageFormat = {
     setup: (wrapper, ad) => {
         return new Promise((resolve) => {
             wrapper.insertCSS(styles);
-            if (ad) setDimensionsUntilAdvantageAdSlot(ad, false);
+            if (ad) {
+                setDimensionsUntilAdvantageAdSlot(ad, false);
+                // Override publisher max-width constraints (e.g. tv2.no's max-width: 1920px)
+                // so the creative fills the full viewport width
+                ad.style.maxWidth = "none";
+            }
 
             const uiContainer = document.createElement("div");
             uiContainer.id = "ui-container";
@@ -46,6 +51,7 @@ export const doubleMidscrollSingle: AdvantageFormat = {
     reset: (wrapper, ad?) => {
         if (ad) {
             resetDimensionsUntilAdvantageAdSlot(ad, false);
+            ad.style.maxWidth = "";
         }
         wrapper.resetCSS();
         

--- a/src/advantage/formats/double-midscroll-single.ts
+++ b/src/advantage/formats/double-midscroll-single.ts
@@ -32,9 +32,6 @@ export const doubleMidscrollSingle: AdvantageFormat = {
             wrapper.insertCSS(styles);
             if (ad) {
                 setDimensionsUntilAdvantageAdSlot(ad, false);
-                // Override publisher max-width constraints (e.g. tv2.no's max-width: 1920px)
-                // so the creative fills the full viewport width
-                ad.style.maxWidth = "none";
             }
 
             const uiContainer = document.createElement("div");
@@ -51,7 +48,6 @@ export const doubleMidscrollSingle: AdvantageFormat = {
     reset: (wrapper, ad?) => {
         if (ad) {
             resetDimensionsUntilAdvantageAdSlot(ad, false);
-            ad.style.maxWidth = "";
         }
         wrapper.resetCSS();
         

--- a/www/docs/concepts/formats.md
+++ b/www/docs/concepts/formats.md
@@ -22,6 +22,7 @@ These are the current built-in format identifiers:
 export enum AdvantageFormatName {
     TopScroll = "TOPSCROLL",
     DoubleMidscroll = "DOUBLE_MIDSCROLL",
+    DoubleMidscrollSingleCreative = "DOUBLE_MIDSCROLL_SINGLE_CREATIVE",
     Midscroll = "MIDSCROLL",
     WelcomePage = "WELCOME_PAGE"
 }
@@ -50,3 +51,9 @@ Midscroll format is defined by its appearance (taking 100% width and height of t
 The Double Midscroll is a responsive, high-impact format that provides a natural presentation of your message through an intuitive and user-friendly scrolling experience. This format becomes visible when the user scrolls past the content and remains visible until the scrolling distance reaches twice the height of the window.
 
 <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">Width 100%</span> <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">Height: 200%</span> <span class="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">Parallax Scrolling</span>
+
+## Double Midscroll Single Creative
+
+A simplified version of the Double Midscroll that requires only one creative file instead of two. Provides continuous scroll progress events (0-1) instead of discrete waypoints, allowing a single creative to implement its own scroll-based animations. Ideal for tag-based creative delivery.
+
+<span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">Width 100%</span> <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">Height: 200%</span> <span class="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">Parallax Scrolling</span> <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-700/10">Scroll Progress Events</span>


### PR DESCRIPTION
### Description

Fixes an issue where `DOUBLE_MIDSCROLL_SINGLE_CREATIVE` didn't fill the full viewport width on publishers that apply `max-width` constraints to the iframe (e.g. tv2.no's `max-width: 1920px`).

**Changes:**
- Override publisher `max-width` with inline style so the creative always goes full-width
- Fix `:host` positioning in padded ad containers with `margin-left: calc((100% - 100vw) / 2)`
- Add the format to the docs sidebar and format overview page (was missing from navigation)

**Why this is needed:**
The standard `DOUBLE_MIDSCROLL` avoids this because its background iframe lives inside Shadow DOM, unreachable by page CSS. The single creative variant only has a foreground iframe, so it's subject to publisher constraints. The inline style override fixes this cleanly.

### Issues Resolved

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 license.