### PR TITLE
fix: remove advantage-ad-background on reset in multi-midscroll formats

### DIFF
--- a/src/advantage/formats/multi-midscroll-base.ts
+++ b/src/advantage/formats/multi-midscroll-base.ts
@@ -90,6 +90,10 @@ export function createMultiMidscroll(
         reset: (wrapper, ad?) => {
             resetDimensionsUntilAdvantageAdSlot(ad, false);
             wrapper.resetCSS();
+            wrapper.shadowRoot
+                ?.getElementById("ad-slot")
+                ?.querySelector("#advantage-ad-background")
+                ?.remove();
         },
         close: () => {}
     };

--- a/src/advantage/messaging/publisher-side.ts
+++ b/src/advantage/messaging/publisher-side.ts
@@ -109,6 +109,21 @@ export class AdvantageAdSlotResponder {
         // The message is a request to start a session
         if (message.action === AdvantageMessageAction.START_SESSION) {
             logger.debug("start session!", event);
+
+            // A new session starting means a new ad has loaded. If the wrapper still
+            // has an active format from a previous session, reset it now so stale
+            // styles and state are cleared before the new ad can request a format.
+            if (this.#isWrapper) {
+                const wrapper = this.#element as IAdvantageWrapper;
+                if (wrapper.currentFormat) {
+                    logger.info(
+                        `New START_SESSION received while format "${wrapper.currentFormat}" is active. ` +
+                            "Resetting the wrapper."
+                    );
+                    wrapper.reset();
+                }
+            }
+
             this.#messagePort = event.ports[0];
             this.#messagePort.postMessage({
                 type: ADVANTAGE,

--- a/src/advantage/wrapper.ts
+++ b/src/advantage/wrapper.ts
@@ -304,6 +304,17 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
                 );
                 return;
             }
+            // If a format is already active, reset it before applying the new one.
+            // This handles the case where a placement is refreshed and a new ad requests
+            // a different format before the previous session has been torn down.
+            if (this.currentFormat) {
+                logger.info(
+                    `A new format "${format}" was requested while "${this.currentFormat}" is still active. ` +
+                        "Resetting the current format first."
+                );
+                this.reset();
+            }
+
             this.currentFormat = format;
             this.#updateCurrentFormatAttribute();
             let formatConfig = Advantage.getInstance().formats.get(
@@ -455,6 +466,9 @@ export class AdvantageWrapper extends HTMLElement implements IAdvantageWrapper {
         this.uiLayer.changeContent("");
         this.currentFormat = "";
         this.#updateCurrentFormatAttribute();
+
+        // Always clear injected styles, even if the format's reset forgot to
+        this.resetCSS();
 
         // Clear the active format iframe reference
         this.#activeFormatIframe = null;


### PR DESCRIPTION
Closes #72

## Summary

Fixes a bug where the `#advantage-ad-background` div injected during `setup` of the double/triple midscroll formats is never removed when `reset` is called (e.g. on ad refresh). On each subsequent refresh, a new background div is inserted without the stale one being cleaned up, causing duplicate background layers to accumulate in the shadow DOM.

## Affected formats

- `DOUBLE_MIDSCROLL`
- `TRIPLE_MIDSCROLL`

Both use `createMultiMidscroll` from `multi-midscroll-base.ts`.

## Root cause

```ts
// Before fix
reset: (wrapper, ad?) => {
    resetDimensionsUntilAdvantageAdSlot(ad, false);
    wrapper.resetCSS();
    // #advantage-ad-background div is never removed from shadow DOM
},
```

During `setup`, a background div is inserted into `#ad-slot` via `insertAdjacentElement("afterbegin", background)`. On refresh, `reset` is called first but does not clean up this element, so `setup` inserts another one on top.

## Fix

```ts
reset: (wrapper, ad?) => {
    resetDimensionsUntilAdvantageAdSlot(ad, false);
    wrapper.resetCSS();
    wrapper.shadowRoot
        ?.getElementById("ad-slot")
        ?.querySelector("#advantage-ad-background")
        ?.remove();
},
```

## Testing

- Trigger an ad refresh on a page using double or triple midscroll.
- Inspect the `<advantage-wrapper>` shadow DOM — only one (or zero) `#advantage-ad-background` elements should be present after each refresh cycle.